### PR TITLE
iframe allow attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metal-heaven/rh24-webapp-sdk",
-  "version": "2.0.0-rc1",
+  "version": "2.0.1",
   "description": "Rh24 webapp integration library",
   "files": [
     "dist/**/*"

--- a/src/__tests__/rh24-webapp-sdk.test.ts
+++ b/src/__tests__/rh24-webapp-sdk.test.ts
@@ -72,6 +72,14 @@ test('should append random v parameter with ? if no query strings are present in
   expect(iframe.src).toMatch(/\?v=[d]*/)
 })
 
+test('should add the parameter to allow clipboard read and write from app domain', () => {
+  const iframe = renderRhodium('app', '/path')
+
+  expect(iframe.allow).toBe(
+    'clipboard-write self https://unit-test.rhodium24.io; clipboard-read self https://unit-test.rhodium24.io'
+  )
+})
+
 test('should not append random v parameter if enable cache is true', () => {
   rh24 = new Rh24WebApp({
     partyId: 'test-party',

--- a/src/rh24-webapp-sdk.ts
+++ b/src/rh24-webapp-sdk.ts
@@ -71,6 +71,8 @@ export class Rh24WebApp {
     iframe.sandbox =
       'allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation allow-downloads allow-popups allow-popups-to-escape-sandbox'
 
+    iframe.allow = `clipboard-write self ${this._config.rh24BaseUrl}; clipboard-read self ${this._config.rh24BaseUrl}`
+
     element.style.overflowY = 'hidden'
 
     element.appendChild(iframe)


### PR DESCRIPTION
to access the clipboard API inside an iframe tag, the iframe should explicity use the `allow` attribute to allow write and read from the clipboard. Since it's a cross domain request, also needs to specify the domain that should be allowed to use the API. 