### PR TITLE
Fix/gd/remove self origin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metal-heaven/rh24-webapp-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metal-heaven/rh24-webapp-sdk",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "devDependencies": {
         "@mui/material": "^5.0.6",
         "@types/jest": "^29.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metal-heaven/rh24-webapp-sdk",
-  "version": "2.0.0-rc1",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metal-heaven/rh24-webapp-sdk",
-      "version": "2.0.0-rc1",
+      "version": "2.0.1",
       "devDependencies": {
         "@mui/material": "^5.0.6",
         "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metal-heaven/rh24-webapp-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Rh24 webapp integration library",
   "files": [
     "dist/**/*"

--- a/src/__tests__/rh24-webapp-sdk.test.ts
+++ b/src/__tests__/rh24-webapp-sdk.test.ts
@@ -76,7 +76,7 @@ test('should add the parameter to allow clipboard read and write from app domain
   const iframe = renderRhodium('app', '/path')
 
   expect(iframe.allow).toBe(
-    'clipboard-write self https://unit-test.rhodium24.io; clipboard-read self https://unit-test.rhodium24.io'
+    'clipboard-write https://unit-test.rhodium24.io; clipboard-read https://unit-test.rhodium24.io'
   )
 })
 

--- a/src/rh24-webapp-sdk.ts
+++ b/src/rh24-webapp-sdk.ts
@@ -55,8 +55,6 @@ export class Rh24WebApp {
     if (!this._config.options?.enableCache) {
       iframeSrc += `${iframeSrc.indexOf('?') > -1 ? '&' : '?'}v=${Math.random()}`
       iframeSrc = iframeSrc.replace('/?', '?')
-
-      console.info('cache disabled', iframeSrc)
     }
 
     iframe.src = iframeSrc
@@ -71,7 +69,7 @@ export class Rh24WebApp {
     iframe.sandbox =
       'allow-top-navigation allow-scripts allow-same-origin allow-forms allow-modals allow-top-navigation-by-user-activation allow-downloads allow-popups allow-popups-to-escape-sandbox'
 
-    iframe.allow = `clipboard-write self ${this._config.rh24BaseUrl}; clipboard-read self ${this._config.rh24BaseUrl}`
+    iframe.allow = `clipboard-write ${this._config.rh24BaseUrl}; clipboard-read ${this._config.rh24BaseUrl}`
 
     element.style.overflowY = 'hidden'
 


### PR DESCRIPTION
Removes "self" from the list of allowed origins since Chrome warns that it is not a valid origin (it was deprecated).